### PR TITLE
Se asigna una altura fija para las imagenes de portada

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-apexcharts": "^1.4.0",
         "react-bootstrap": "^2.7.4",
         "react-bootstrap-icons": "^1.10.3",
+        "react-cropper": "^2.3.3",
         "react-data-table-component": "^7.5.3",
         "react-dom": "^18.2.0",
         "react-lazy-load-image-component": "^1.6.0",
@@ -6550,6 +6551,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/cropperjs": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.6.2.tgz",
+      "integrity": "sha512-nhymn9GdnV3CqiEHJVai54TULFAE3VshJTXSqSJKa8yXAKyBKDWdhHarnlIPrshJ0WMFTGuFvG02YjLXfPiuOA=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -15166,6 +15172,17 @@
         "react": ">=16.8.6"
       }
     },
+    "node_modules/react-cropper": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/react-cropper/-/react-cropper-2.3.3.tgz",
+      "integrity": "sha512-zghiEYkUb41kqtu+2jpX2Ntigf+Jj1dF9ew4lAobPzI2adaPE31z0p+5TcWngK6TvmWQUwK3lj4G+NDh1PDQ1w==",
+      "dependencies": {
+        "cropperjs": "^1.5.13"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.2"
+      }
+    },
     "node_modules/react-data-table-component": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/react-data-table-component/-/react-data-table-component-7.5.3.tgz",
@@ -23668,6 +23685,11 @@
         "yaml": "^1.10.0"
       }
     },
+    "cropperjs": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.6.2.tgz",
+      "integrity": "sha512-nhymn9GdnV3CqiEHJVai54TULFAE3VshJTXSqSJKa8yXAKyBKDWdhHarnlIPrshJ0WMFTGuFvG02YjLXfPiuOA=="
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -29895,6 +29917,14 @@
       "integrity": "sha512-j4hSby6gT9/enhl3ybB1tfr1slZNAYXDVntcRrmVjxB3//2WwqrzpESVqKhyayYVaWpEtnwf9wgUQ03cuziwrw==",
       "requires": {
         "prop-types": "^15.7.2"
+      }
+    },
+    "react-cropper": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/react-cropper/-/react-cropper-2.3.3.tgz",
+      "integrity": "sha512-zghiEYkUb41kqtu+2jpX2Ntigf+Jj1dF9ew4lAobPzI2adaPE31z0p+5TcWngK6TvmWQUwK3lj4G+NDh1PDQ1w==",
+      "requires": {
+        "cropperjs": "^1.5.13"
       }
     },
     "react-data-table-component": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-apexcharts": "^1.4.0",
     "react-bootstrap": "^2.7.4",
     "react-bootstrap-icons": "^1.10.3",
+    "react-cropper": "^2.3.3",
     "react-data-table-component": "^7.5.3",
     "react-dom": "^18.2.0",
     "react-lazy-load-image-component": "^1.6.0",

--- a/src/components/Gallery/Gallery.jsx
+++ b/src/components/Gallery/Gallery.jsx
@@ -166,6 +166,7 @@ const Gallery = ({ searchValue = '', keyword = '' }) => {
                 <PublicationCard
                   key={publication.id}
                   publication={publication}
+                  heigth='h-96'
                   className={`${
                     index === 0
                       ? 'col-span-3 lg:col-span-2'
@@ -196,6 +197,7 @@ const Gallery = ({ searchValue = '', keyword = '' }) => {
                   <PublicationCard
                     key={publication.id}
                     publication={publication}
+                    heigth='h-56'
                     className={`${index === 0 ? 'lg:hidden' : ''}`}
                   />
                 )

--- a/src/components/Gallery/PublicationCard.jsx
+++ b/src/components/Gallery/PublicationCard.jsx
@@ -14,7 +14,7 @@ export function formatoFecha(fecha) {
   return dia + ' ' + mesYAnio;
 }
 
-const PublicationCard = ({ publication, className = '' }) => {
+const PublicationCard = ({ publication, className = '', heigth = '' }) => {
   const navigate = useNavigate();
   // Define el ancho máximo para considerar la pantalla como pequeña
   const isSmallScreen = useMediaQuery({ maxWidth: 640 });
@@ -35,7 +35,7 @@ const PublicationCard = ({ publication, className = '' }) => {
       )}
       <img
         className={`w-full ${
-          isSmallScreen ? 'h-48' : 'max-h-96'
+          isSmallScreen ? 'h-48' : heigth || 'max-h-96'
         } object-cover object-center rounded-t-lg transition duration-300 ease-in-out hover:opacity-60`}
         src={
           (publication?.images && publication?.images[0]?.url) ||

--- a/src/components/Publications/Form/Form.jsx
+++ b/src/components/Publications/Form/Form.jsx
@@ -328,6 +328,7 @@ const Form = ({ publication } = null) => {
             type: 'error',
             autoClose: 3000,
           });
+          console.error(error);
         }
       );
   };
@@ -977,11 +978,12 @@ const Form = ({ publication } = null) => {
           <h2 className="mt-6 text-[28px] text-primary font-principal">
             Agregar Fotos
           </h2>
+          <div>
           <ImagesUploader
             onImagesChange={(images) => setImageFiles(images)}
             imagesUrls={publication ? publication.images : null}
           />
-
+          </div>
           <h2 className="mt-6 mb-3 text-[28px] text-primary font-principal">
             Agregar Preguntas
           </h2>

--- a/src/components/Publications/Form/ImagesUploader.jsx
+++ b/src/components/Publications/Form/ImagesUploader.jsx
@@ -1,51 +1,68 @@
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import Cropper from 'react-cropper';
+import 'cropperjs/dist/cropper.css';
 
 const ImagesUploader = ({ onImagesChange, imagesUrls }) => {
   const [selectedFiles, setSelectedFiles] = useState([]);
+  const [croppedImages, setCroppedImages] = useState([]);
+  const cropperRef = useRef(null);
 
   useEffect(() => {
-    onImagesChange(selectedFiles);
-  }, [selectedFiles]);
+    onImagesChange(croppedImages);
+  }, [croppedImages]);
 
-  const handleDeleteImage = indexImage => {
-    const newImagesState = selectedFiles.filter(
-      (files, currentIndex) => currentIndex !== indexImage
+  const handleDeleteImage = (indexImage) => {
+    const newImagesState = croppedImages.filter(
+      (file, currentIndex) => currentIndex !== indexImage
     );
-    setSelectedFiles(newImagesState);
+    setCroppedImages(newImagesState);
   };
 
-  const handleDragEnter = event => {
+  const handleDragEnter = (event) => {
     event.preventDefault();
   };
 
-  const handleDragOver = event => {
+  const handleDragOver = (event) => {
     event.preventDefault();
   };
 
-  const handleDrop = event => {
+  const handleDrop = (event) => {
     event.preventDefault();
-    const files = event.dataTransfer.files;
+    const files = Array.from(event.dataTransfer.files);
     setSelectedFiles([...selectedFiles, ...files]);
+  };
+
+  const handleCrop = () => {
+    const cropper = cropperRef.current.cropper;
+    cropper.getCroppedCanvas().toBlob((blob) => {
+      if (blob) {
+        const originalFile = selectedFiles[selectedFiles.length - 1];
+        const croppedFile = new File([blob], originalFile.name, {
+          type: originalFile.type,
+        });
+        setCroppedImages([...croppedImages, croppedFile]);
+      }
+    });
   };
 
   return (
     <div
-      className={`flex flex-col justify-center items-center mt-10 h-72 mx-auto border-2 
+      className={`flex flex-col justify-center items-center mt-10 p-10 mx-auto border-2 
       border-dashed border-secondary text-lg font-bold`}
       onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
     >
       <div className="flex flex-col items-center">
-        <p className="hidden md:block">Arrastre y suelte la imagen aqui, o haga click en</p>
+      <p className="hidden md:block">Arrastre y suelte la imagen aquí, o haga click en</p>
         <label
           htmlFor="images"
-          className="mt-2 cursor-pointer border border-solid border-blue-
+          className="mt-2 cursor-pointer border border-solid border-blue-600
           bg-blue-600 py-2 px-4 rounded text-white"
         >
-          Seleccionar Imagenes
+          Seleccionar Imágenes
         </label>
         <input
           type="file"
@@ -53,14 +70,31 @@ const ImagesUploader = ({ onImagesChange, imagesUrls }) => {
           name="images"
           id="images"
           className="hidden"
-          onChange={event => {
-            setSelectedFiles([...selectedFiles, ...event.target.files]);
+          onChange={(event) => {
+            setSelectedFiles([...selectedFiles, ...Array.from(event.target.files)]);
           }}
         />
       </div>
+      <div className="mt-8 w-full flex flex-col items-center">
+        {selectedFiles.length !== 0 && (
+          <Cropper
+            ref={cropperRef}
+            src={URL.createObjectURL(selectedFiles[selectedFiles.length - 1])}
+            style={{ height: 400, width: '80%' }}
+            aspectRatio={16 / 9}
+            guides={false}
+          />
+        )}
+        <button
+          onClick={handleCrop}
+          className={selectedFiles.length !== 0 ? "mt-4 w-40 bg-green-500 text-white py-2 px-4 rounded" : "hidden"}
+        >
+          Recortar Imagen
+        </button>
+      </div>
       <div className="hidden md:flex flex-wrap gap-4 mt-8">
-        {selectedFiles.length !== 0
-          ? selectedFiles.map((image, index) => (
+      {croppedImages.length !== 0
+          ? croppedImages.map((image, index) => (
               <div key={`${index}-images-files`} className="relative h-26">
                 <button
                   type="button"

--- a/src/pages/Publication/index.jsx
+++ b/src/pages/Publication/index.jsx
@@ -230,7 +230,7 @@ const Publication = () => {
         <div className="flex mb-3 md:mb-8">
           {publication?.images?.length > 0 && (
             <img
-              className="imgSingle mx-auto w-[98%] md:max-w-[87%] lg:max-w-[75%] 2xl:max-w-[60%] rounded-md shadow-lg shadow-gray-400"
+              className="imgSingle mx-auto h-48 md:h-96 w-[98%] md:max-w-[87%] lg:max-w-[75%] 2xl:max-w-[60%] rounded-md shadow-lg shadow-gray-400"
               src={publication.images[0].url}
               alt="Imagen principal"
             />


### PR DESCRIPTION
Se asigna una altura fija para las imagenes de portada
Se agrega la librería react-cropper para estandarizar las proporciones de las imágenes, las deje configurada para que todas las imágenes se corten en relación 16:9. Así nos aseguramos de mantener un aspecto uniforme en todas las publicaciones